### PR TITLE
Introduce reusable layout and state management

### DIFF
--- a/components/core/DataLoader.tsx
+++ b/components/core/DataLoader.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export type DataLoaderProps<T> = {
+  fetchData: () => Promise<T>;
+  onData?: (data: T) => void;
+  children: (data: T) => React.ReactNode;
+};
+
+/**
+ * Generic data loading component.
+ *
+ * The consumer provides a fetch function and a render prop to handle the result.
+ */
+export function DataLoader<T>({ fetchData, onData, children }: DataLoaderProps<T>) {
+  const [data, setData] = React.useState<T | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    fetchData().then(result => {
+      if (mounted) {
+        setData(result);
+        onData?.(result);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [fetchData]);
+
+  if (data === null) return <div>Loading...</div>;
+  return <>{children(data)}</>;
+}

--- a/components/core/GameInfoLoader.tsx
+++ b/components/core/GameInfoLoader.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { DataLoader } from './DataLoader';
+import { useGameStore, GameInfo } from '../../store/gameStore';
+
+/**
+ * Loads game configuration from `game.json` and stores it in the global store.
+ */
+export const GameInfoLoader: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const setGameInfo = useGameStore(state => state.setGameInfo);
+  return (
+    <DataLoader<GameInfo>
+      fetchData={() => fetch('/game.json').then(res => res.json())}
+      onData={setGameInfo}
+    >
+      {() => <>{children}</>}
+    </DataLoader>
+  );
+};
+

--- a/components/core/GameLayout.tsx
+++ b/components/core/GameLayout.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export const GameLayout: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div className="min-h-screen flex flex-col">{children}</div>
+);
+
+export const GameHeader: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <header className="w-full flex justify-center mb-4">{children}</header>
+);
+
+export const GameBody: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <main className="flex-grow flex flex-col items-center">{children}</main>
+);
+
+export const GameFooter: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <footer className="w-full mt-4">{children}</footer>
+);

--- a/components/game/GameContainer.tsx
+++ b/components/game/GameContainer.tsx
@@ -18,7 +18,8 @@
  *  - App.tsx (implicitly, as it wraps all screen content)
  */
 import React from 'react';
-import GameHeader from './GameHeader'; // Import the new GameHeader component
+import GameHeader from './GameHeader'; // Title component specific to BlameGame
+import { GameLayout, GameHeader as LayoutHeader, GameBody, GameFooter } from '../core/GameLayout';
 
 interface GameContainerProps {
   children: React.ReactNode;
@@ -41,10 +42,17 @@ const GameContainer: React.FC<GameContainerProps> = ({ children, onTitleClick })
       className="min-h-screen w-full flex flex-col items-center justify-start px-2 sm:px-4 py-4 bg-gradient-to-b from-pink-500 to-pink-300"
       style={{ minHeight: '100dvh' }}
     >
-      <GameHeader title="BlameGame" onTitleClick={onTitleClick} /> {/* Pass onTitleClick to GameHeader */}
-      <div className="w-full max-w-md flex-grow flex flex-col items-center justify-center">
-        {children}
-      </div>
+      <GameLayout>
+        <LayoutHeader>
+          <GameHeader onTitleClick={onTitleClick} />
+        </LayoutHeader>
+        <GameBody>
+          <div className="w-full max-w-md flex-grow flex flex-col items-center justify-center">
+            {children}
+          </div>
+        </GameBody>
+        <GameFooter />
+      </GameLayout>
     </div>
   );
 };

--- a/components/game/GameHeader.tsx
+++ b/components/game/GameHeader.tsx
@@ -12,9 +12,10 @@
  *  - React
  */
 import React from 'react';
+import { useGameStore } from '../../store/gameStore';
 
 interface GameHeaderProps {
-  title: string;
+  title?: string;
   onTitleClick?: () => void; // Add optional click handler prop
 }
 
@@ -27,6 +28,8 @@ interface GameHeaderProps {
  * @returns A styled header element containing the game title.
  */
 const GameHeader: React.FC<GameHeaderProps> = ({ title, onTitleClick }) => {
+  const storeTitle = useGameStore(state => state.gameInfo?.title);
+  const finalTitle = title ?? storeTitle ?? 'BlameGame';
   return (
     <div className="w-full flex justify-center">
       <div className="shadow-2xl rounded-2xl border-pink-200 px-8 py-6 max-w-2xl w-stretch flex justify-center items-center bg-white/70 backdrop-blur-md">
@@ -35,7 +38,7 @@ const GameHeader: React.FC<GameHeaderProps> = ({ title, onTitleClick }) => {
           style={{ fontFamily: "'Orbitron', 'Montserrat', 'Segoe UI', monospace" }}
           onClick={onTitleClick}
         >
-          {title}
+          {finalTitle}
         </h1>
       </div>
     </div>

--- a/docs/COMPONENT_STRUCTURE.md
+++ b/docs/COMPONENT_STRUCTURE.md
@@ -36,6 +36,8 @@ The `components/core/` directory contains **reusable UI components** that are no
 - `Slider.tsx` - Range input slider
 - `Switch.tsx` - Toggle switch input
 - `VolumeControl.tsx` - Audio volume control
+- `DataLoader.tsx` - Generic loader using render props
+- `GameLayout.tsx` - Provides `GameHeader`, `GameBody`, and `GameFooter` shells
 
 ## 3. Game Components
 

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -12,7 +12,7 @@ BlameGame is a party game built with **React**, **TypeScript**, **Tailwind CSS**
 - **components/game/** – Screens and logic specific to gameplay.
 - **components/settings/** – Configuration screens including language selection.
 - **hooks/** – Custom hooks handling state and data fetching.
-- **context/GameContext** – (currently empty) placeholder for global state.
+- **store/** – Shared Zustand store for global game state.
 - **lib/** – Utility functions and constants.
 
 ## Architecture Sketch

--- a/hooks/useGameSettings.ts
+++ b/hooks/useGameSettings.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import useLocalStorage from './useLocalStorage';
 import { GameSettings } from '../types';
 import { initialGameSettings } from '../constants';
+import { useGameStore } from '../store/gameStore';
 
 /**
  * Custom React hook for managing game settings using local storage.
@@ -14,21 +15,29 @@ import { initialGameSettings } from '../constants';
  * Uses the `useLocalStorage` hook to persist settings under the key `'blamegame-settings'`.
  */
 export const useGameSettings = () => {
-  const [gameSettings, setGameSettings] = useLocalStorage<GameSettings>(
-    'blamegame-settings', 
+  const storeGameSettings = useGameStore(state => state.gameSettings);
+  const setStoreGameSettings = useGameStore(state => state.setGameSettings);
+  const updateStoreGameSettings = useGameStore(state => state.updateGameSettings);
+
+  const [persistedSettings, setPersistedSettings] = useLocalStorage<GameSettings>(
+    'blamegame-settings',
     initialGameSettings
   );
 
-  const updateGameSettings = (newSettings: Partial<GameSettings>) => {
-    setGameSettings({
-      ...gameSettings,
-      ...newSettings
-    });
-  };
+  // Initialize store from persisted settings on mount
+  useEffect(() => {
+    setStoreGameSettings(persistedSettings);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist to localStorage whenever store settings change
+  useEffect(() => {
+    setPersistedSettings(storeGameSettings);
+  }, [storeGameSettings, setPersistedSettings]);
 
   return {
-    gameSettings,
-    setGameSettings,
-    updateGameSettings
+    gameSettings: storeGameSettings,
+    setGameSettings: setStoreGameSettings,
+    updateGameSettings: updateStoreGameSettings,
   };
 };

--- a/index.tsx
+++ b/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 // Import i18n instance before App to ensure it's initialized
 import './lib/localization/i18n';
 import App from './App';
+import { GameInfoLoader } from './components/core/GameInfoLoader';
 import { registerSW } from 'virtual:pwa-register';
 
 // Register service worker for PWA
@@ -27,6 +28,8 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <App />
+    <GameInfoLoader>
+      <App />
+    </GameInfoLoader>
   </React.StrictMode>
 );

--- a/lib/localization/i18n.ts
+++ b/lib/localization/i18n.ts
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import { translations } from './index'; // Assuming this exports your translations map
+import { translations } from './index';
 
 // Configure i18next with required plugins
 i18n
@@ -11,7 +11,7 @@ i18n
     resources: translations,
     fallbackLng: 'de', // Default to German if translation is missing
     supportedLngs: ['de', 'en', 'es', 'fr'],
-    debug: false, // Set to false as default
+    debug: false,
     interpolation: {
       escapeValue: false, // React already protects from XSS
     },
@@ -23,7 +23,7 @@ i18n
     },
     react: {
       useSuspense: false, // Disable suspense to avoid issues
-    }
+    },
   });
 
 export default i18n;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,12 @@
         "react-feather": "^2.0.10",
         "react-i18next": "^15.5.1",
         "tailwind-merge": "^3.2.0",
-        "workbox-window": "^7.3.0"
+        "workbox-window": "^7.3.0",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@types/i18next": "^12.1.0",
+        "@types/node": "^22.15.18",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@types/react-i18next": "^7.8.3",
@@ -3120,6 +3122,16 @@
       "integrity": "sha512-qLyqTkp3ZKHsSoX8CNVYcTyTkxlm0aRCUpaUVetgkSlSpiNCdWryOgaYwgbO04tJIfLgBXPcy0tJ3Nl/RagllA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.2",
@@ -8557,6 +8569,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -9402,6 +9421,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-feather": "^2.0.10",
     "react-i18next": "^15.5.1",
     "tailwind-merge": "^3.2.0",
-    "workbox-window": "^7.3.0"
+    "workbox-window": "^7.3.0",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@types/i18next": "^12.1.0",

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+import { GameSettings } from "../types";
+import { initialGameSettings } from "../constants";
+
+export type GameState = "not_started" | "in_progress" | "finished";
+
+export interface GameInfo {
+  name: string;
+  title: string;
+  description: string;
+  domain: string;
+  icon: string;
+  minPlayers: number;
+  maxPlayers: number;
+  playMode: string;
+  deviceRequirement: string;
+  tags: string[];
+}
+
+interface Store {
+  state: GameState;
+  setState: (state: GameState) => void;
+
+  gameInfo?: GameInfo;
+  setGameInfo: (info: GameInfo) => void;
+
+  gameSettings: GameSettings;
+  setGameSettings: (settings: GameSettings) => void;
+  updateGameSettings: (settings: Partial<GameSettings>) => void;
+
+  settings: Record<string, unknown>;
+  setSetting: (key: string, value: unknown) => void;
+  stats: Record<string, number>;
+  updateStat: (key: string, value: number) => void;
+}
+
+/**
+ * Global game store managed with zustand.
+ * Components can subscribe to this store to share state across the app.
+ */
+export const useGameStore = create<Store>((set) => ({
+  state: "not_started",
+  setState: (state) => set({ state }),
+  gameInfo: undefined,
+  setGameInfo: (info) => set({ gameInfo: info }),
+
+  gameSettings: initialGameSettings,
+  setGameSettings: (settings) => set({ gameSettings: settings }),
+  updateGameSettings: (settings) =>
+    set((s) => ({ gameSettings: { ...s.gameSettings, ...settings } })),
+  settings: {},
+  setSetting: (key, value) =>
+    set((s) => ({ settings: { ...s.settings, [key]: value } })),
+  stats: {},
+  updateStat: (key, value) =>
+    set((s) => ({ stats: { ...s.stats, [key]: value } })),
+}));


### PR DESCRIPTION
## Summary
- add generic `DataLoader` component
- provide `GameLayout` with `GameHeader`, `GameBody` and `GameFooter`
- integrate layout shells in `GameContainer`
- add zustand-based `gameStore`
- document new modules and update project overview
- include zustand dependency
- use store-backed `GameInfoLoader` for config
- load title from store in `GameHeader`
- sync game settings through the store and clean i18n setup

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685183959fb0832691c2a1087642d929