### PR TITLE
Fix GameInfo loading on custom domain

### DIFF
--- a/components/core/GameInfoLoader.tsx
+++ b/components/core/GameInfoLoader.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
 import { DataLoader } from './DataLoader';
 import { useGameStore, GameInfo } from '../../store/gameStore';
+import { fetchAsset } from '../../lib/utils/fetchUtils';
 
 /**
- * Loads game configuration from `game.json` and stores it in the global store.
+ * GameInfoLoader Component
+ *
+ * Purpose: Fetches the game's meta information from `game.json` and writes it
+ *          into the global zustand store so any component can access it.
+ *
+ * Props:
+ *  - children: React.ReactNode - React children to render once the data is
+ *    loaded.
+ *
+ * Expected Behavior: On mount, this component retrieves `game.json` using
+ * `fetchAsset`, stores the result via `useGameStore`, and then renders its
+ * children. If the fetch fails, the underlying DataLoader handles the error
+ * state.
+ *
+ * Dependencies:
+ *  - React
+ *  - DataLoader (for generic async handling)
+ *  - zustand store from `useGameStore`
+ *  - fetchAsset utility for path-safe fetches
+ *
+ * Integrated by: index.tsx wraps the entire <App /> with this loader.
  */
 export const GameInfoLoader: React.FC<React.PropsWithChildren> = ({ children }) => {
   const setGameInfo = useGameStore(state => state.setGameInfo);
   return (
     <DataLoader<GameInfo>
-      fetchData={() => fetch('/game.json').then(res => res.json())}
+      fetchData={() => fetchAsset('game.json').then(res => res.json())}
       onData={setGameInfo}
     >
       {() => <>{children}</>}

--- a/docs/plan-fix-gameinfo-loader-path.md
+++ b/docs/plan-fix-gameinfo-loader-path.md
@@ -1,0 +1,29 @@
+# Plan: Fix GameInfoLoader Path
+
+## Feature Name/Bugfix Title
+Ensure `GameInfoLoader` correctly loads `game.json` in all deployment environments.
+
+## Goals & Expected Behavior
+- `game.json` should be fetched successfully both locally and on GitHub Pages/custom domains.
+- App should no longer display a blank page due to failing JSON fetch.
+
+## Technical Steps
+1. Copy `game.json` to the `public/` directory so it is included in the build output.
+2. Update `GameInfoLoader` to use `fetchAsset('game.json')` which applies `getAssetsPath` and retry logic.
+3. Extend `verify-assets.js` to check that `game.json` exists in `public` and the build `dist` directory.
+4. Add/update documentation comments as required.
+
+## Potential Edge Cases
+- Incorrect base path could still break the fetch if environment variables are misconfigured.
+- Cached old versions of the service worker may continue serving stale files until refreshed.
+
+## Impact on Existing Files or UX
+- No direct UI changes.
+- Ensures initial configuration loads correctly and prevents the app from hanging on "Loading".
+
+## Checklist
+- [x] `game.json` copied to `public/`
+- [x] `GameInfoLoader` uses `fetchAsset`
+- [x] `verify-assets.js` validates presence of `game.json`
+- [x] Documentation comments updated
+

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,3 @@
+# TODO
+
+- [x] [Fix GameInfoLoader path](plan-fix-gameinfo-loader-path.md)

--- a/public/game.json
+++ b/public/game.json
@@ -1,0 +1,12 @@
+{
+  "name": "blamegame",
+  "title": "BlameGame",
+  "description": "Who do you want to blame and for what?",
+  "domain": "https://blamegame.leagueoffun.de",
+  "icon": "https://blamegame.leagueoffun.de/logo.png",
+  "minPlayers": 3,
+  "maxPlayers": 16,
+  "playMode": "local",
+  "deviceRequirement": "shared",
+  "tags": ["humor", "deduction", "chaos"]
+}

--- a/scripts/verify-assets.js
+++ b/scripts/verify-assets.js
@@ -118,6 +118,18 @@ const verifyPWAIcons = () => {
   return allValid;
 };
 
+// Verify game.json exists in public
+const verifyGameJson = () => {
+  const gamePath = path.join(PUBLIC_DIR, 'game.json');
+  if (fileExists(gamePath)) {
+    console.log('✅ game.json exists');
+    return true;
+  } else {
+    console.error('❌ game.json is missing');
+    return false;
+  }
+};
+
 // Verify CNAME file
 const verifyCNAME = () => {
   const cnamePath = path.join(PUBLIC_DIR, 'CNAME');
@@ -159,7 +171,8 @@ const verifyDistDirectory = () => {
   const criticalFiles = [
     'index.html',
     'CNAME',
-    'questions/categories.json'
+    'questions/categories.json',
+    'game.json'
   ];
   
   let allValid = true;
@@ -186,6 +199,7 @@ const verifyAssets = () => {
   allValid = verifyCategoriesFile() && allValid;
   allValid = verifyLanguageDirectories() && allValid;
   allValid = verifyPWAIcons() && allValid;
+  allValid = verifyGameJson() && allValid;
   allValid = verifyCNAME() && allValid;
   
   // Verify dist if requested


### PR DESCRIPTION
## Summary
- copy `game.json` to `public/` so it ships with the build
- use `fetchAsset` in `GameInfoLoader` for base path aware fetches
- verify `game.json` in `verify-assets.js`
- document plan and mark todo

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run verify-assets`


------
https://chatgpt.com/codex/tasks/task_e_68518ed3d4c4832680cdc921674db819