### PR TITLE
Improve loading and logging

### DIFF
--- a/components/core/DataLoader.tsx
+++ b/components/core/DataLoader.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import ErrorDisplay from './ErrorDisplay';
+import { logger } from '../../lib/utils/logger';
 
 export type DataLoaderProps<T> = {
   fetchData: () => Promise<T>;
@@ -13,20 +15,30 @@ export type DataLoaderProps<T> = {
  */
 export function DataLoader<T>({ fetchData, onData, children }: DataLoaderProps<T>) {
   const [data, setData] = React.useState<T | null>(null);
+  const [error, setError] = React.useState<Error | null>(null);
 
   React.useEffect(() => {
     let mounted = true;
-    fetchData().then(result => {
-      if (mounted) {
-        setData(result);
-        onData?.(result);
-      }
-    });
+    fetchData()
+      .then(result => {
+        if (mounted) {
+          logger.log('DATA', 'Loaded data');
+          setData(result);
+          onData?.(result);
+        }
+      })
+      .catch(err => {
+        logger.error('DATA', 'DataLoader error', err);
+        if (mounted) {
+          setError(err as Error);
+        }
+      });
     return () => {
       mounted = false;
     };
-  }, [fetchData]);
+  }, [fetchData, onData]);
 
+  if (error) return <ErrorDisplay message={error.message} />;
   if (data === null) return <div>Loading...</div>;
   return <>{children(data)}</>;
 }

--- a/components/core/GameInfoLoader.tsx
+++ b/components/core/GameInfoLoader.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { DataLoader } from './DataLoader';
 import { useGameStore, GameInfo } from '../../store/gameStore';
-import { fetchAsset } from '../../lib/utils/fetchUtils';
+import { fetchAssetWithFallback } from '../../lib/utils/fetchUtils';
+import { logger } from '../../lib/utils/logger';
 
 /**
  * GameInfoLoader Component
@@ -14,7 +15,7 @@ import { fetchAsset } from '../../lib/utils/fetchUtils';
  *    loaded.
  *
  * Expected Behavior: On mount, this component retrieves `game.json` using
- * `fetchAsset`, stores the result via `useGameStore`, and then renders its
+ * `fetchAssetWithFallback`, stores the result via `useGameStore`, and then renders its
  * children. If the fetch fails, the underlying DataLoader handles the error
  * state.
  *
@@ -22,7 +23,7 @@ import { fetchAsset } from '../../lib/utils/fetchUtils';
  *  - React
  *  - DataLoader (for generic async handling)
  *  - zustand store from `useGameStore`
- *  - fetchAsset utility for path-safe fetches
+ *  - fetchAssetWithFallback utility for path-safe fetches
  *
  * Integrated by: index.tsx wraps the entire <App /> with this loader.
  */
@@ -30,8 +31,11 @@ export const GameInfoLoader: React.FC<React.PropsWithChildren> = ({ children }) 
   const setGameInfo = useGameStore(state => state.setGameInfo);
   return (
     <DataLoader<GameInfo>
-      fetchData={() => fetchAsset('game.json').then(res => res.json())}
-      onData={setGameInfo}
+      fetchData={() => fetchAssetWithFallback('game.json').then(res => res.json())}
+      onData={(info) => {
+        logger.log('GAME', 'Game info loaded');
+        setGameInfo(info);
+      }}
     >
       {() => <>{children}</>}
     </DataLoader>

--- a/docs/plan-fix-gameinfo-loader-path.md
+++ b/docs/plan-fix-gameinfo-loader-path.md
@@ -9,7 +9,7 @@ Ensure `GameInfoLoader` correctly loads `game.json` in all deployment environmen
 
 ## Technical Steps
 1. Copy `game.json` to the `public/` directory so it is included in the build output.
-2. Update `GameInfoLoader` to use `fetchAsset('game.json')` which applies `getAssetsPath` and retry logic.
+2. Update `GameInfoLoader` to use `fetchAssetWithFallback('game.json')` which applies `getAssetsPath` and adds a fallback for legacy deployments.
 3. Extend `verify-assets.js` to check that `game.json` exists in `public` and the build `dist` directory.
 4. Add/update documentation comments as required.
 
@@ -23,7 +23,7 @@ Ensure `GameInfoLoader` correctly loads `game.json` in all deployment environmen
 
 ## Checklist
 - [x] `game.json` copied to `public/`
-- [x] `GameInfoLoader` uses `fetchAsset`
+ - [x] `GameInfoLoader` uses `fetchAssetWithFallback`
 - [x] `verify-assets.js` validates presence of `game.json`
 - [x] Documentation comments updated
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,3 +2,6 @@
 
 export * from './arrayUtils';
 export * from './cn'; // Add this line to export the cn function
+export * from './fetchUtils';
+export * from './assetUtils';
+export * from './logger';

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -1,0 +1,25 @@
+export const isDebugMode = (): boolean => {
+  if (typeof window !== 'undefined') {
+    return new URLSearchParams(window.location.search).get('debug') === 'true';
+  }
+  return false;
+};
+
+export const logger = {
+  log(tag: string, ...args: unknown[]) {
+    if (isDebugMode()) {
+      console.log(`[${tag}]`, ...args);
+    }
+  },
+  warn(tag: string, ...args: unknown[]) {
+    if (isDebugMode()) {
+      console.warn(`[${tag}]`, ...args);
+    }
+  },
+  error(tag: string, ...args: unknown[]) {
+    if (isDebugMode()) {
+      console.error(`[${tag}]`, ...args);
+    }
+  }
+};
+


### PR DESCRIPTION
## Summary
- add simple logger utility
- show ErrorDisplay in DataLoader and log events
- log when GameInfo loads
- export logger from utilities

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build:domain`
- `npm run verify-build` *(reports missing assets but completes)*

------
https://chatgpt.com/codex/tasks/task_e_68642fbd0ea08326bfdf305ac6ed0e94